### PR TITLE
age: remove '.gpg' file extention from output

### DIFF
--- a/extensions/age.bash
+++ b/extensions/age.bash
@@ -26,5 +26,5 @@ cd $PREFIX
     done
 
     # This will now be sorted and shown
-) | sort | awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}'
+) | sort | sed 's/\.gpg$//' | awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}'
 


### PR DESCRIPTION
This pull request addresses [Issue 4](https://github.com/skx/pass/issues/4)

The `.gpg` file extension is removed from the output of `pass age`.