### PR TITLE
env: also quote env vars when exec'ing

### DIFF
--- a/extensions/env.bash
+++ b/extensions/env.bash
@@ -107,7 +107,7 @@ cmd_env_set() {
               echo "export ${key}=\"${pwd}\""
           else
               # Exec is set, so export the value directly
-              export ${key}=${pwd}
+              export ${key}="${pwd}"
           fi
       fi
   done <<< "$contents"


### PR DESCRIPTION
When using --exec along with a password file containing shell special characters, env vars were not exported properly to the exec'd process.

These values previously resulted in a mess but are now correctly handled.
```
  value_with_spaces: a b c
  value_with_semicolons: a;b;c;
  value_with_quotes: a"b"c"
  value_with_asterisks: **abc**
```