### PR TITLE
env: add standalone completion file for env extension

### DIFF
--- a/completion/pass-env.bash-completion
+++ b/completion/pass-env.bash-completion
@@ -1,0 +1,6 @@
+# completion file for bash for the 'env' extension to password-store
+
+__password_store_extension_complete_env() {
+    COMPREPLY+=($(compgen -W "--exec --version" -- ${cur}))
+    _pass_complete_entries 1
+}


### PR DESCRIPTION
pass allows extensions to provide shell completion [1] by implementing the function `__password_store_extension_complete_<COMMAND>` and adding the name of the extension to the `PASSWORD_STORE_EXTENSION_COMMANDS` array like this in their bashrc file:
```
  PASSWORD_STORE_EXTENSION_COMMANDS+=('env')
```
pass will then invoke the provided function to complete the subcommand's options and parameters.

[1] https://git.zx2c4.com/password-store/tree/src/completion/pass.bash-completion#n128